### PR TITLE
Fix response parsing bug

### DIFF
--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -28,7 +28,9 @@ function session (req, res, next) {
   var session = req.cookies.session;
   if (!session) 
     return res.redirect('/');
-  session.response.Message = session.response.Message
+  session.response.Type = session.response.Type || session.response.type;
+  session.response.ClientState = session.response.ClientState || session.response.clientState || session.response.client_state;
+  session.response.Message = session.response.Message || session.response.message
     .substr(0, 182)
     .replace(/\r\n/g, '<br>')
     .replace(/\n/g, '<br>')


### PR DESCRIPTION
Bug fix

App crashes when the property names returned in the UssdResponse are not
PascalCased i.e. camelCase and snake_case property names returned by
some servers e.g. rails causes the mocker to crash